### PR TITLE
Implement dired-like marks for torrents

### DIFF
--- a/transmission.el
+++ b/transmission.el
@@ -186,6 +186,19 @@ Useful if `transmission-geoip-function' does not have its own
 caching built in or is otherwise slow."
   :type 'boolean)
 
+(defgroup transmission-faces nil
+  "Faces used by Transmission buffers."
+  :group 'transmission
+  :group 'faces)
+
+(defface transmission-mark
+  '((t (:inherit font-lock-constant-face)))
+  "Face used by Transmission marks."
+  :group 'transmission-faces)
+
+(defvar transmission-mark-face 'transmission-mark
+  "Face name used for marked torrents.")
+
 (defconst transmission-mode-alist
   '((session . 0)
     (torrent . 1)
@@ -264,6 +277,9 @@ Should accept the torrent ID as an argument, e.g. `transmission-torrent-id'.")
 
 (defvar transmission-geoip-hash (copy-hash-table transmission-hash-table)
   "Hash table storing associations between IP addresses and location names.")
+
+(defvar-local transmission-marked-torrent-ids nil
+  "IDs of the currently marked torrents.")
 
 
 ;; JSON RPC
@@ -838,6 +854,7 @@ point or in region--is non-nil, then BINDINGS and BODY are fed to
 `let*'.  Else, a `user-error' is signalled."
   (declare (indent 1) (debug t))
   `(let ((ids (or (and transmission-torrent-id (list transmission-torrent-id))
+                  transmission-marked-torrent-ids
                   (mapcar (lambda (id) (cdr (assq 'id id)))
                           (transmission-prop-values-in-region 'tabulated-list-id)))))
      (if ids
@@ -914,6 +931,7 @@ When called with a prefix, prompt for DIRECTORY."
        (prompt (format "Move torrent%s to %s? " (if (cdr ids) "s" "") location)))
     (when (y-or-n-p prompt)
       (setq deactivate-mark t)
+      (setq transmission-marked-torrent-ids nil)
       (transmission-request-async nil "torrent-set-location" arguments))))
 
 (defun transmission-reannounce ()
@@ -921,6 +939,7 @@ When called with a prefix, prompt for DIRECTORY."
   (interactive)
   (transmission-let*-ids nil
     (setq deactivate-mark t)
+    (setq transmission-marked-torrent-ids nil)
     (transmission-request-async nil "torrent-reannounce" (list :ids ids))))
 
 (defun transmission-remove (&optional unlink)
@@ -931,6 +950,7 @@ When called with a prefix UNLINK, also unlink torrent data on disk."
     (when (yes-or-no-p (concat "Remove " (and unlink "and unlink ")
                                "torrent" (and (< 1 (length ids)) "s") "? "))
       (setq deactivate-mark t)
+      (setq transmission-marked-torrent-ids nil)
       (transmission-request-async nil "torrent-remove" arguments))))
 
 (defun transmission-set-bandwidth-priority ()
@@ -1007,6 +1027,7 @@ When called with a prefix UNLINK, also unlink torrent data on disk."
   (interactive)
   (transmission-let*-ids nil
     (setq deactivate-mark t)
+    (setq transmission-marked-torrent-ids nil)
     (transmission-request-async
      (lambda (content)
        (let* ((torrents (transmission-torrents (json-read-from-string content)))
@@ -1151,6 +1172,24 @@ When called with a prefix UNLINK, also unlink torrent data on disk."
     (when magnet
       (kill-new magnet)
       (message "Copied %s" magnet))))
+
+(defun transmission-toggle-mark ()
+  "Toggle mark of the current torrent."
+  (interactive)
+  (let ((id (cdr (assq 'id (tabulated-list-get-id)))))
+    (if (member id transmission-marked-torrent-ids)
+        (progn
+          (setf transmission-marked-torrent-ids (delete id transmission-marked-torrent-ids))
+          (tabulated-list-put-tag " " t))
+      (push id transmission-marked-torrent-ids)
+      (tabulated-list-put-tag (propertize "*" 'font-lock-face transmission-mark-face) t))))
+
+(defun transmission-unmark-all ()
+  "Remove mark from all torrents."
+  (interactive)
+  (when transmission-marked-torrent-ids
+    (setf transmission-marked-torrent-ids nil)
+    (transmission-refresh)))
 
 
 ;; Formatting
@@ -1444,6 +1483,19 @@ Also run the timer for timer object `transmission-timer'."
                  (goto-char (point-min)))))
            (pop-to-buffer-same-window buffer))))))
 
+(defun transmission-print-torrent (id cols)
+  "Insert a torrent entry at point using `tabulated-list-print-entry'.
+Put the mark tag in the padding area of the current line if the current
+torrent is marked.
+ID is a Lisp object identifying the entry to print, and COLS is a vector
+of column descriptors."
+  (tabulated-list-print-entry id cols)
+  (let* ((torrent-id (cdr (assq 'id id))))
+    (when (member torrent-id transmission-marked-torrent-ids)
+      (save-excursion
+        (forward-line -1)
+        (tabulated-list-put-tag (propertize "*" 'font-lock-face transmission-mark-face))))))
+
 
 ;; Major mode definitions
 
@@ -1638,6 +1690,8 @@ Key bindings:
     (define-key map "v" 'transmission-verify)
     (define-key map "q" 'transmission-quit)
     (define-key map "y" 'transmission-set-bandwidth-priority)
+    (define-key map "x" 'transmission-toggle-mark)
+    (define-key map "U" 'transmission-unmark-all)
     map)
   "Keymap used in `transmission-mode' buffers.")
 
@@ -1661,6 +1715,9 @@ Key bindings:
     ["Move Torrent" transmission-move]
     ["Reannounce Torrent" transmission-reannounce]
     ["Verify Torrent" transmission-verify]
+    "--"
+    ["Toggle mark" transmission-toggle-mark]
+    ["Unmark all" transmission-unmark-all]
     "--"
     ["View Torrent Files" transmission-files]
     ["View Torrent Info" transmission-info]
@@ -1695,8 +1752,10 @@ Key bindings:
            :right-align t)
           ("Status" 11 t)
           ("Name" 0 t)])
+  (setq tabulated-list-padding 2)
   (transmission-tabulated-list-format)
   (setq transmission-refresh-function #'transmission-draw-torrents)
+  (setq tabulated-list-printer #'transmission-print-torrent)
   (setq-local revert-buffer-function #'transmission-refresh)
   (add-hook 'post-command-hook #'transmission-timer-check nil t)
   (add-hook 'before-revert-hook #'transmission-tabulated-list-format nil t))


### PR DESCRIPTION
This change features two new commands:
- `transmission-toggle-mark` &mdash; mark/unmark torrent at point. It's bound to <kbd>x</kbd>; I would be happy to use <kbd>SPC</kbd> instead, but it's already bound to `scroll-up` by the parent mode.
- `transmission-unmark-all` &mdash; remove all marks (bound to <kbd>U</kbd>).

Marking takes precedence over selecting torrents via regions in functions which use `transmission-let*-ids`. That is, if there're marked torrents, their IDs are bound to `ids` in `transmission-let*-ids` (with fallback to the IDs obtained via `transmission-prop-values-in-region` if none torrents are marked).

Closes #3.
