### PR TITLE
Improve magnet link handling

### DIFF
--- a/README.org
+++ b/README.org
@@ -15,7 +15,7 @@ commentary in =transmission.el=.
 
 * Installation
 
-Available as the =transmission= package on MELPA <http://melpa.org/>
+Available as the =transmission= package on MELPA <https://melpa.org/>
 and marmalade <https://marmalade-repo.org/>.
 
 One can install as a package with

--- a/README.org
+++ b/README.org
@@ -8,15 +8,9 @@ commentary in =transmission.el=.
 #+NAME: fig:example
 [[./example.png]]
 
-# * About
-# https://trac.transmissionbt.com/browser/trunk/extras/rpc-spec.txt
-# https://github.com/fagga/transmission-remote-cli
-# https://trac.transmissionbt.com/browser/trunk/daemon/remote.c
-
 * Installation
 
-Available as the =transmission= package on MELPA <https://melpa.org/>
-and marmalade <https://marmalade-repo.org/>.
+Available as the =transmission= package on MELPA <https://melpa.org/>.
 
 One can install as a package with
 

--- a/transmission.el
+++ b/transmission.el
@@ -1112,7 +1112,9 @@ WINDOW with `window-start' and the line/column coordinates of `point'."
 ;;;###autoload
 (defun transmission-add (torrent &optional directory)
   "Add TORRENT by filename, URL, magnet link, or info hash.
-When called with a prefix, prompt for DIRECTORY."
+When called with a prefix, prompt for DIRECTORY. When used
+interactively, magnet link will be fetched from the top
+kill ring entry."
   (interactive
    (let* ((f (transmission-collect-hook 'transmission-torrent-functions))
           (def (mapcar #'file-relative-name f))

--- a/transmission.el
+++ b/transmission.el
@@ -1113,8 +1113,8 @@ WINDOW with `window-start' and the line/column coordinates of `point'."
 (defun transmission-add (torrent &optional directory)
   "Add TORRENT by filename, URL, magnet link, or info hash.
 When called with a prefix, prompt for DIRECTORY. When used
-interactively, magnet link will be fetched from the top
-kill ring entry."
+interactively, will try to fetch magnet link
+from `transmission-torrent-functions'."
   (interactive
    (let* ((f (transmission-collect-hook 'transmission-torrent-functions))
           (def (mapcar #'file-relative-name f))

--- a/transmission.el
+++ b/transmission.el
@@ -1102,7 +1102,9 @@ WINDOW with `window-start' and the line/column coordinates of `point'."
   (and (stringp string)
        (let ((magnet-link-string-indicator "magnet:?xt="))
 	 (string-equal magnet-link-string-indicator
-		       (substring string 0 (length magnet-link-string-indicator))))))
+		       (substring string 0
+				  (min (length string)
+				       (length magnet-link-string-indicator)))))))
 
 
 ;; Interactive

--- a/transmission.el
+++ b/transmission.el
@@ -50,7 +50,7 @@
 ;; line utility transmission-remote(1), the ncurses interface
 ;; transmission-remote-cli(1), and the rtorrent(1) client.  These can
 ;; be found respectively at the following:
-;; <https://github.com/transmission/transmission/blob/master/daemon/remote.c>
+;; <https://github.com/transmission/transmission/blob/master/utils/remote.c>
 ;; <https://github.com/fagga/transmission-remote-cli>
 ;; <https://rakshasa.github.io/rtorrent/>
 

--- a/transmission.el
+++ b/transmission.el
@@ -1099,9 +1099,10 @@ WINDOW with `window-start' and the line/column coordinates of `point'."
        (unless ,old-mark-active (deactivate-mark)))))
 
 (defun looks-like-a-magnet-link-p (string)
-  (let ((magnet-link-string-indicator "magnet:?xt="))
-    (string-equal magnet-link-string-indicator
-		  (substring string 0 (length magnet-link-string-indicator)))))
+  (and (stringp string)
+       (let ((magnet-link-string-indicator "magnet:?xt="))
+	 (string-equal magnet-link-string-indicator
+		       (substring string 0 (length magnet-link-string-indicator))))))
 
 
 ;; Interactive

--- a/transmission.el
+++ b/transmission.el
@@ -395,7 +395,7 @@ and port default to `transmission-host' and
     (let* ((user (plist-get transmission-rpc-auth :username))
            (pass (and user (or (plist-get transmission-rpc-auth :password)
                                (transmission--auth-source-secret user)))))
-      (concat "Basic " (base64-encode-string (concat user ":" pass))))))
+      (concat "Basic " (base64-encode-string (concat user ":" pass) t)))))
 
 (defun transmission-http-post (process content)
   "Send to PROCESS an HTTP POST request containing CONTENT."
@@ -1127,7 +1127,7 @@ When called with a prefix, prompt for DIRECTORY."
    (append (if (and (file-readable-p torrent) (not (file-directory-p torrent)))
                `(:metainfo ,(with-temp-buffer
                               (insert-file-contents-literally torrent)
-                              (base64-encode-string (buffer-string))))
+                              (base64-encode-string (buffer-string) t)))
              (setq torrent (string-trim torrent))
              `(:filename ,(if (transmission-btih-p torrent)
                               (concat "magnet:?xt=urn:btih:" torrent)

--- a/transmission.el
+++ b/transmission.el
@@ -2023,10 +2023,14 @@ is constructed from TEST, BODY and the `tabulated-list-id' tagged as `<>'."
 (define-transmission-predicate download>? > (cdr (assq 'rateToClient <>)))
 (define-transmission-predicate upload>? > (cdr (assq 'rateToPeer <>)))
 (define-transmission-predicate size>? > (cdr (assq 'length <>)))
-(define-transmission-predicate eta>? > (cdr (assq 'eta <>)))
 (define-transmission-predicate size-when-done>? > (cdr (assq 'sizeWhenDone <>)))
 (define-transmission-predicate percent-done>? > (cdr (assq 'percentDone <>)))
 (define-transmission-predicate ratio>? > (cdr (assq 'uploadRatio <>)))
+
+(define-transmission-predicate eta>=? >=
+  (let-alist <>
+    (if (>= .eta 0) .eta
+      (- 1.0 .percentDone))))
 
 (defvar transmission-peers-mode-map
   (let ((map (make-sparse-keymap)))
@@ -2301,7 +2305,7 @@ Transmission."
   :group 'transmission
   (setq-local line-move-visual nil)
   (setq tabulated-list-format
-        [("ETA" 4 transmission-eta>? :right-align t)
+        [("ETA" 4 transmission-eta>=? :right-align t)
          ("Size" 9 transmission-size-when-done>?
           :right-align t :transmission-size t)
          ("Have" 4 transmission-percent-done>? :right-align t)

--- a/transmission.el
+++ b/transmission.el
@@ -1625,9 +1625,9 @@ Otherwise, with a prefix arg, mark files on the next ARG lines."
   "Toggle mark on all items."
   (interactive)
   (let ((inhibit-read-only t) ids tag key)
-    (when (setq key (pcase-exhaustive major-mode
-                      (`transmission-mode 'id)
-                      (`transmission-files-mode 'index)))
+    (when (setq key (cl-ecase major-mode
+                      (transmission-mode 'id)
+                      (transmission-files-mode 'index)))
       (save-excursion
         (save-restriction
           (widen)
@@ -1989,9 +1989,9 @@ torrent is marked.
 ID is a Lisp object identifying the entry to print, and COLS is a vector
 of column descriptors."
   (tabulated-list-print-entry id cols)
-  (let* ((key (pcase-exhaustive major-mode
-                (`transmission-mode 'id)
-                (`transmission-files-mode 'index)))
+  (let* ((key (cl-ecase major-mode
+                (transmission-mode 'id)
+                (transmission-files-mode 'index)))
          (item-id (cdr (assq key id))))
     (when (memq item-id transmission-marked-ids)
       (save-excursion

--- a/transmission.el
+++ b/transmission.el
@@ -1,6 +1,6 @@
 ;;; transmission.el --- Interface to a Transmission session -*- lexical-binding: t -*-
 
-;; Copyright (C) 2014-2018  Mark Oteiza <mvoteiza@udel.edu>
+;; Copyright (C) 2014-2019  Mark Oteiza <mvoteiza@udel.edu>
 
 ;; Author: Mark Oteiza <mvoteiza@udel.edu>
 ;; Version: 0.12.1


### PR DESCRIPTION
Interactive `transmission-add` is quite broken for magnet links at the moment.

Arguably, magnet links are almost always provided via kill ring, or are fed into transmission-add non-interactively. Non-interactive use shows no issues. (When I `(transmission-add "magnet:?xt=...")` from repl, torrent is added properly.)

However, when called interactively, the user is prompted: “Add torrent [...]: ”. Suppose user now removes whatever is written in input field and inserts magnet link from kill ring.

Debugger shows
transmission-add("/path/to/some/dir/magnet:?xt=..." nil)
with some directory (default-directory?) prefixed for no reason.

In addition, the prompt itself depends on a variety of sources including the last killed item in kill ring, for reasons not entirely clear to me but likely not very well thought through. When a magnet link is last killed, it is shown in the prompt while the input field contains a directory path which is extremely confusing. (Is transmission going to start this magnet download into this directory? — Alas, it is not.) Furthermore, on my Emacs (26.0.90), if 'not' is last killed, a 'notes.org' is added to the prompt, which is some extremely far-fetching guess that certainly has nothing to do with anything transmission.

I propose a patch that attempts to guess if magnet-link is provided via one of the `transmission-torrent-functions` (in fact it might be better to search by means of one hook only, this is debatable). If something resembling magnet link is found, it is (attempted to be) added automatically. The prompt is not modified in this case. The latter might seem silly, as the effect is instantaneous but 1) it just doesn't feel right; 2) modifying prompt only makes sense for filenames while `transmission-add`'s docstring claims to accept much more than filenames *or* magnet links, so it's likely that more has to yet be done in this regard.

The patch does not fix misguided guessing (see the not / notes.org example above) but does not make it worse either.