### PR TITLE
replaced obsolete function (url-get-url-at-point) with (thing-at-poin…

### DIFF
--- a/transmission.el
+++ b/transmission.el
@@ -807,11 +807,11 @@ NOW is a time, defaulting to `current-time'."
 (defun transmission-ffap ()
   "Return a file name, URL, or info hash at point, otherwise nil."
   (or (get-text-property (point) 'shr-url)
-      (get-text-property (point) :nt-link)
-      (let ((fn (run-hook-with-args-until-success 'file-name-at-point-functions)))
-        (unless (transmission-directory-name-p fn) fn))
-      (url-get-url-at-point)
-      (transmission-btih-p (thing-at-point 'word))))
+     (get-text-property (point) :nt-link)
+     (let ((fn (run-hook-with-args-until-success 'file-name-at-point-functions)))
+       (unless (transmission-directory-name-p fn) fn))
+     (thing-at-point-url-at-point)
+     (transmission-btih-p (thing-at-point 'word))))
 
 (defun transmission-ffap-string (string)
   "Apply `transmission-ffap' to the beginning of STRING."


### PR DESCRIPTION
Installing or upgrading transmission.el gives the following warning `In transmission-ffap:
transmission.el:815:8:Warning: ‘url-get-url-at-point’ is an obsolete function
    (as of 27.1); use ‘thing-at-point-url-at-point’ instead.`

So I changed `url-get-url-at-point` to the recommended `thing-at-point-url-at-point`.