### PR TITLE
Add rename-path command

### DIFF
--- a/transmission.el
+++ b/transmission.el
@@ -1664,6 +1664,39 @@ Otherwise, with a prefix arg, mark files on the next ARG lines."
       (setq transmission-marked-ids ids)
       (set-buffer-modified-p nil))))
 
+(defun transmission-files-rename-path (torrent-id old-path new-name)
+  "Rename an OLD-PATH to NEW-NAME of TORRENT-ID.
+
+TORRENT-ID is a hashString of torrent.
+
+OLD-PATH is a path to file in a torrent.  It can be a directory
+or a file.
+
+NEW-NAME is a new name of a file at OLD-PATH.
+
+When called interactively, values are taken from current buffer
+with `transmission-files-mode'.  OLD-PATH can be set explicitly
+with prefix argument, otherwise the file at point is taken.
+
+Note: it is forbidden to move a file to other locations, only
+renaming is allowed."
+  (interactive
+   (let* ((old-path (cdr (assq 'name (tabulated-list-get-id))))
+          (old-path-prompt (format "Old path (default %s): " old-path))
+          (old-path (if current-prefix-arg
+                        (read-string old-path-prompt nil nil old-path)
+                      old-path))
+          (new-name (file-name-nondirectory old-path))
+          (new-name-prompt (format "Rename %s to: " new-name))
+          (new-name (read-string new-name-prompt nil nil new-name)))
+     (list transmission-torrent-id old-path new-name)))
+
+  (when (string= new-name (file-name-nondirectory old-path))
+    (user-error "Cannot rename to the same name: %s" new-name))
+
+  (let ((arguments (list :ids (list torrent-id) :path old-path :name new-name)))
+    (transmission-request-async nil "torrent-rename-path" arguments)))
+
 
 ;; Turtle mode
 
@@ -2213,6 +2246,7 @@ for explanation of the peer flags."
     (define-key map "v" 'transmission-view-file)
     (define-key map "w" 'transmission-files-want)
     (define-key map "y" 'transmission-files-priority)
+    (define-key map "R" 'transmission-files-rename-path)
     map)
   "Keymap used in `transmission-files-mode' buffers.")
 


### PR DESCRIPTION
Added a `transmission-files-rename-path` command. It can rename paths inside torrent.  