### PR TITLE
Replace usage of switch-to-buffer-other-window with pop-to-buffer

### DIFF
--- a/transmission.el
+++ b/transmission.el
@@ -2399,7 +2399,7 @@ Transmission."
             (error
              (kill-buffer buffer)
              (signal (car e) (cdr e))))))
-      (switch-to-buffer-other-window buffer))))
+      (pop-to-buffer buffer))))
 
 (provide 'transmission)
 


### PR DESCRIPTION
They work in the same way but `switch-to-buffer-other-window` cannot be customized via `display-buffer-alist`.